### PR TITLE
CLI debugging setting

### DIFF
--- a/src/BackgroundTask.php
+++ b/src/BackgroundTask.php
@@ -18,6 +18,7 @@
 
 namespace Rhubarb\Scaffolds\BackgroundTasks;
 
+use Rhubarb\Crown\Context;
 use Rhubarb\Crown\Logging\Log;
 use Rhubarb\Scaffolds\BackgroundTasks\Models\BackgroundTaskStatus;
 
@@ -79,7 +80,17 @@ abstract class BackgroundTask
             $additionalArgumentString .= escapeshellarg($argument);
         }
 
-        $command = "/usr/bin/php " . realpath("vendor/rhubarbphp/rhubarb/platform/execute-cli.php") . " " . realpath(__DIR__ . "/Scripts/task-runner.php") . " " . escapeshellarg( get_called_class() )." ".$task->BackgroundTaskStatusID . " ".$additionalArgumentString." > /dev/null 2>&1 &";
+        $context = new Context();
+        if ($context->PhpIdeConfig) {
+            // This setting can be used to make command line tasks use a named configuration
+            // in your IDE - this matches up to the PHP Server name in PhpStorm, found in
+            // Settings -> Languages and Frameworks -> PHP -> Servers -> Name
+            $command = 'export PHP_IDE_CONFIG="serverName='.$context->PhpIdeConfig.'";';
+        } else {
+            $command = '';
+        }
+
+        $command .= "/usr/bin/php " . realpath("vendor/rhubarbphp/rhubarb/platform/execute-cli.php") . " " . realpath(__DIR__ . "/Scripts/task-runner.php") . " " . escapeshellarg( get_called_class() )." ".$task->BackgroundTaskStatusID . " ".$additionalArgumentString." > /dev/null 2>&1 &";
 
         Log::debug( "Launching background task ".$task->UniqueIdentifier, "BACKGROUND", $command );
 

--- a/src/BackgroundTask.php
+++ b/src/BackgroundTask.php
@@ -55,7 +55,7 @@ abstract class BackgroundTask
      *
      * @param $rawShellArguments
      */
-    public static function setShellArguments( $rawShellArguments )
+    public static function setShellArguments($rawShellArguments)
     {
         self::$shellArguments = $rawShellArguments;
     }
@@ -65,7 +65,7 @@ abstract class BackgroundTask
      *
      * @return BackgroundTaskStatus The status object for this task.
      */
-    public static function initiate( $settings = [] )
+    public static function initiate($settings = [])
     {
         // Create an entry in our database.
         $task = new BackgroundTaskStatus();
@@ -76,7 +76,7 @@ abstract class BackgroundTask
         $additionalArguments = static::getAdditionalTaskRunnerArguments();
         $additionalArgumentString = "";
 
-        foreach( $additionalArguments as $argument ){
+        foreach ($additionalArguments as $argument) {
             $additionalArgumentString .= escapeshellarg($argument);
         }
 
@@ -85,14 +85,15 @@ abstract class BackgroundTask
             // This setting can be used to make command line tasks use a named configuration
             // in your IDE - this matches up to the PHP Server name in PhpStorm, found in
             // Settings -> Languages and Frameworks -> PHP -> Servers -> Name
-            $command = 'export PHP_IDE_CONFIG="serverName='.$context->PhpIdeConfig.'";';
+
+            $command = 'export PHP_IDE_CONFIG=' . escapeshellarg('serverName=' . $context->PhpIdeConfig) . ';';
         } else {
             $command = '';
         }
 
-        $command .= "/usr/bin/php " . realpath("vendor/rhubarbphp/rhubarb/platform/execute-cli.php") . " " . realpath(__DIR__ . "/Scripts/task-runner.php") . " " . escapeshellarg( get_called_class() )." ".$task->BackgroundTaskStatusID . " ".$additionalArgumentString." > /dev/null 2>&1 &";
+        $command .= "/usr/bin/php " . realpath("vendor/rhubarbphp/rhubarb/platform/execute-cli.php") . " " . realpath(__DIR__ . "/Scripts/task-runner.php") . " " . escapeshellarg(get_called_class()) . " " . $task->BackgroundTaskStatusID . " " . $additionalArgumentString . " > /dev/null 2>&1 &";
 
-        Log::debug( "Launching background task ".$task->UniqueIdentifier, "BACKGROUND", $command );
+        Log::debug("Launching background task " . $task->UniqueIdentifier, "BACKGROUND", $command);
 
         exec($command);
 


### PR DESCRIPTION
Added allowance for a Context setting which can provide the PHP_IDE_CONFIG environment variable value to match up to PhpStorm's Server name to allow CLI debugging of background tasks.

I found that the most convenient way to ensure this variable is set is to do it in the same command as the one which runs the background task.
