### PR TITLE
Using '/usr/bin/env php' to kick off bg tasks.

### DIFF
--- a/src/BackgroundTask.php
+++ b/src/BackgroundTask.php
@@ -91,7 +91,7 @@ abstract class BackgroundTask
             $command = '';
         }
 
-        $command .= "/usr/bin/php " . realpath("vendor/rhubarbphp/rhubarb/platform/execute-cli.php") . " " . realpath(__DIR__ . "/Scripts/task-runner.php") . " " . escapeshellarg(get_called_class()) . " " . $task->BackgroundTaskStatusID . " " . $additionalArgumentString . " > /dev/null 2>&1 &";
+        $command .= "/usr/bin/env php " . realpath("vendor/rhubarbphp/rhubarb/platform/execute-cli.php") . " " . realpath(__DIR__ . "/Scripts/task-runner.php") . " " . escapeshellarg(get_called_class()) . " " . $task->BackgroundTaskStatusID . " " . $additionalArgumentString . " > /dev/null 2>&1 &";
 
         Log::debug("Launching background task " . $task->UniqueIdentifier, "BACKGROUND", $command);
 


### PR DESCRIPTION
Using '/usr/bin/env php' means that the location of the PHP executable becomes less of an issue.
This will make the scaffold more distro independent.
